### PR TITLE
Fix for multiple nano scrollers in parent > children

### DIFF
--- a/bin/javascripts/jquery.nanoscroller.js
+++ b/bin/javascripts/jquery.nanoscroller.js
@@ -494,8 +494,8 @@
       if (!this.$el.find("" + paneClass).length && !this.$el.find("" + sliderClass).length) {
         this.$el.append("<div class=\"" + paneClass + "\"><div class=\"" + sliderClass + "\" /></div>");
       }
-      this.slider = this.$el.find("." + sliderClass);
-      this.pane = this.$el.find("." + paneClass);
+      this.pane = this.el.children("." + options.paneClass);
+      this.slider = this.pane.find("." + options.sliderClass);
       if (BROWSER_SCROLLBAR_WIDTH) {
         cssRule = this.$el.css('direction') === 'rtl' ? {
           left: -BROWSER_SCROLLBAR_WIDTH


### PR DESCRIPTION
this.el.find is getting all instances of nano scroller in children
causing them to bind to parent instance. This caused child scroller
slider to be set to parent slider height and move parent scroller.
