### PR TITLE
Allow setting document and window context explicitly

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -90,6 +90,22 @@
     ###
     sliderMaxHeight: null
 
+    ###*
+      an alternate document context.
+      @property documentContext
+      @type Document
+      @default null
+    ###
+    documentContext: null
+
+    ###*
+      an alternate window context.
+      @property windowContext
+      @type Window
+      @default null
+    ###
+    windowContext: null
+
   # Constants
 
   ###*
@@ -281,8 +297,8 @@
     constructor: (@el, @options) ->
       BROWSER_SCROLLBAR_WIDTH or= do getBrowserScrollbarWidth
       @$el = $ @el
-      @doc = $ document
-      @win = $ window
+      @doc = $ @options.documentContext or document
+      @win = $ @options.windowContext or window
       @$content = @$el.children(".#{options.contentClass}")
       @$content.attr 'tabindex', 0
       @content = @$content[0]


### PR DESCRIPTION
Currently, nanoScroller uses the main `document` and `window` objects to wire up events. This causes problems when a scrollable area is instantiated inside an iframe by a parent frame. 

This change allows passing a specific document and window context via options so that scroll/resize/mousemove events are be wired up correctly.
