### PR TITLE
Fix firefox horizontal scrolling issue

### DIFF
--- a/bin/css/nanoscroller.css
+++ b/bin/css/nanoscroller.css
@@ -4,6 +4,7 @@
   width    : 100%;
   height   : 100%;
   overflow : hidden;
+  overflow : -moz-hidden-unscrollable;
 }
 .nano .content {
   position      : absolute;

--- a/bin/css/nanoscroller.less
+++ b/bin/css/nanoscroller.less
@@ -12,6 +12,7 @@
   width: 100%;
   height: 100%;
   overflow: hidden;
+  overflow: -moz-hidden-unscrollable;
   .@{contentClass} {
   position: absolute;
   overflow: scroll;

--- a/bin/css/nanoscroller.scss
+++ b/bin/css/nanoscroller.scss
@@ -12,6 +12,7 @@ $contentClass: "content";
     height: 100%;
     position: relative;
     overflow: hidden;
+    overflow: -moz-hidden-unscrollable;
 
     .#{$contentClass} {
         position: absolute;


### PR DESCRIPTION
Fixes an issue where you could scroll right in the .nano container and see the native scrollbar in firefox.

This behaviour can easily be observed by going to the official homepage (http://jamesflorentino.github.io/nanoScrollerJS/), then clicking once somewhere in the scrollable area and then pressing 'right' (on the keyboard).

Result: The whole content scrolls right and you can see the native scrollbar.

This can be fixed by setting "overflow : -moz-hidden-unscrollable;" on the container.
