### PR TITLE
Requested animation frame should be cancelled

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -422,11 +422,13 @@
         cssValue = top: @sliderTop
 
       if rAF
-        if not @scrollRAF
-          @scrollRAF = rAF =>
-            @scrollRAF = null
-            @slider.css cssValue
-            return
+        if @scrollRAF
+          cAF(@scrollRAF)
+
+        @scrollRAF = rAF =>
+          @scrollRAF = null
+          @slider.css cssValue
+          return
       else
         @slider.css cssValue
       return


### PR DESCRIPTION
The problem is described is #237.

Details: pane animation is behind content animation by 1 step.
That's because you just do nothing if there is planned animation frame. But it was planned step before, so you get wrong animation.
