### PR TITLE
Fix: when dragging the slider, the mouse movements get attached to the s...

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -474,6 +474,9 @@
             @$el.trigger 'scrollend'
           else if @contentScrollTop is 0 and @prevScrollTop isnt 0
             @$el.trigger 'scrolltop'
+            
+            @pane.on 'mouseleave': => @events.up()
+            
           false
 
         up: (e) =>


### PR DESCRIPTION
When the nanoScroller is created dynamicly within a select2 instance, there is an issue - when you start dragging the slider with the mouse, after releasing it (if it is not at the top or bottom) the mouse movement gets translated as scroll.

To fix it I added an event listener for `mouseleave`.
