### PR TITLE
Do not reset newly created scroller; reset height on destroy

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -798,6 +798,7 @@
       do @pane.remove if not @iOSNativeScrolling and @pane.length
       @$content.height '' if BROWSER_IS_IE7
       @$content.removeAttr 'tabindex'
+      @$el.height("")
       if @$el.hasClass('has-scrollbar')
         @$el.removeClass('has-scrollbar')
         @$content.css right: ''
@@ -824,9 +825,11 @@
 
   $.fn.nanoScroller = (settings) ->
     @each ->
+      newScroller = false
       if not scrollbar = @nanoscroller
         options = $.extend {}, defaults, settings
         @nanoscroller = scrollbar = new NanoScroll this, options
+        newScroller = true
 
       # scrollbar settings
       if settings and typeof settings is "object"
@@ -841,7 +844,10 @@
         return do scrollbar.destroy if settings.destroy
         return do scrollbar.flash if settings.flash
 
-      do scrollbar.reset
+        if !newScroller
+          return do scrollbar.reset
+
+      return this
 
   $.fn.nanoScroller.Constructor = NanoScroll
   return


### PR DESCRIPTION
- do not reset a newly created scroller, thus saving ressources and speeding creation up

- set 'height'='' to $el on destroy - this is far from perfect, but it works for any site not setting the height to this element inline; without this, height will be stuck on destroy, so the pages rendering is not returned to normal