### PR TITLE
Bug fix: use @options instead of options

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -359,7 +359,7 @@
       @doc = $ @options.documentContext or document
       @win = $ @options.windowContext or window
       @body= @doc.find 'body'
-      @$content = @$el.children(".#{options.contentClass}")
+      @$content = @$el.children(".#{@options.contentClass}")
       @$content.attr 'tabindex', @options.tabIndex or 0
       @content = @$content[0]
 


### PR DESCRIPTION
This fixes the bug:

```
Uncaught ReferenceError: options is not defined
```

because there isn't a `options` variable but the `@options` instance field.