### PR TITLE
Added jspm/jspm config settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,21 @@
 {
   "name": "nanoscroller",
   "version": "0.0.0-ignored",
+  "main": "javascripts/jquery.nanoscroller.js",
+  "format": "global",
+  "directories": {
+    "lib": "bin"
+  },
+  "dependencies": {
+    "jquery": "^2.1.3",
+    "css": "*"
+  },
+  "shim": {
+    "javascripts/jquery.nanoscroller": [
+      "jquery",
+      "./css/nanoscroller.css!"
+    ]
+  },
   "engines": {
     "node": ">= 0.8.0"
   },


### PR DESCRIPTION
This allows users of jspm to quickly use nano scroller.

I've also added it to the jspm registry here - jspm/registry#235

This means users only need to do: jspm.import(nanoscroller); to get everything (including the css) loaded.

Let me know if that all makes sense!