### PR TITLE
Use !default in sass variables

### DIFF
--- a/bin/css/nanoscroller.scss
+++ b/bin/css/nanoscroller.scss
@@ -2,10 +2,10 @@
 // nanoScrollerJS (Sass)
 // --------------------------------------------------
 /** initial setup **/
-$nanoClass: "nano";
-$paneClass: "nano-pane";
-$sliderClass: "nano-slider";
-$contentClass: "nano-content";
+$nanoClass: "nano" !default;
+$paneClass: "nano-pane" !default;
+$sliderClass: "nano-slider" !default;
+$contentClass: "nano-content" !default;
 
 .#{$nanoClass} {
     width: 100%;


### PR DESCRIPTION
This allows users to easily reuse the "default" style with their own class names.