### PR TITLE
Update min top position

### DIFF
--- a/coffeescripts/jquery.nanoscroller.coffee
+++ b/coffeescripts/jquery.nanoscroller.coffee
@@ -460,7 +460,7 @@
       if not @iOSNativeScrolling
         @maxSliderTop = @paneHeight - @sliderHeight
         # `sliderTop = scrollTop / maxScrollTop * maxSliderTop
-        @sliderTop = if @maxScrollTop is 0 then 0 else @contentScrollTop * @maxSliderTop / @maxScrollTop
+        @sliderTop = if @maxScrollTop <= 0 then 0 else @contentScrollTop * @maxSliderTop / @maxScrollTop
       return
 
     ###*


### PR DESCRIPTION
On Mac while scrolling, slider could be overlapped, cause dragging effects, translate-y reaches it's minimum near -4px. Just make sure we are not bellow zero